### PR TITLE
Word wrap for the Labels so you can see the routing command

### DIFF
--- a/sailfishclient/qml/MainviewPage.qml
+++ b/sailfishclient/qml/MainviewPage.qml
@@ -107,7 +107,10 @@ Page {
 			}
 			Label {
 				id: routinglabel1
+                width: 450
 				text: "test"
+                wrapMode: Text.WordWrap
+                font.bold: true
 				color: "black"
 			}
 			Image {
@@ -117,7 +120,10 @@ Page {
 			}
 			Label {
 				id: routinglabel2
+                width: 450
 				text: "test2"
+                wrapMode: Text.WordWrap
+                font.bold: true
 				color: "black"
 			}
 			
@@ -151,8 +157,8 @@ Page {
 			}
 			Button {
 				width: parent.width/2
-				text: "-"
-				color: "black"
+                text: "-"
+                color: "black"
 
 				onClicked: {
 					mainview.subtractZoom();


### PR DESCRIPTION
I add WordWrap and a width (needed to use WordWrap) to the routinglabel[1|2]. So the routing command is visibile.

See attached screenshot 
![20150308183711](https://cloud.githubusercontent.com/assets/879178/6546921/afedf504-c5c6-11e4-9c70-c313d321f569.jpg)
